### PR TITLE
GitHub Actions implementado

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Pruebas
+
+on:
+    push:
+        paths:
+            - '**.yml' # En caso de editar éste flujo de trabajo u otros
+            - '**.py' # En caso de editar código
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Descargar repo
+              uses: actions/checkout@v3
+            
+            - name: Instalar Python
+              uses: actions/setup-python@v2
+              with:
+                python-version: 3.8
+            
+            - name: Instalar dependencias
+              run: |
+                python -m pip install --upgrade pip
+                pip install -r requirements.txt
+            
+            - name: Ejecutar pruebas
+              run: pytest --junit-xml=test-results.xml # el siguiente paso necesita los resultados en formato XML
+            
+            - name: Mostrar resultados
+              if: always()
+              uses: pmeier/pytest-results-action@v0.3.0
+              with:
+                path: test-results.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: Pruebas
 
 on:
     push:
-        paths:
-            - '**.yml' # En caso de editar éste flujo de trabajo u otros
-            - '**.py' # En caso de editar código
+        paths: ['**.yml', '**.py']
 
 jobs:
     test:
@@ -17,7 +15,7 @@ jobs:
             - name: Instalar Python
               uses: actions/setup-python@v2
               with:
-                python-version: 3.8
+                python-version: 3.9
             
             - name: Instalar dependencias
               run: |
@@ -25,7 +23,7 @@ jobs:
                 pip install -r requirements.txt
             
             - name: Ejecutar pruebas
-              run: pytest --junit-xml=test-results.xml # el siguiente paso necesita los resultados en formato XML
+              run: pytest -v --junit-xml=test-results.xml # el siguiente paso necesita los resultados en formato XML
             
             - name: Mostrar resultados
               if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,4 @@ jobs:
                 pip install -r requirements.txt
             
             - name: Ejecutar pruebas
-              run: pytest -v --junit-xml=test-results.xml # el siguiente paso necesita los resultados en formato XML
-            
-            - name: Publicar resultados
-              uses: EnricoMi/publish-unit-test-result-action@v2.7.0
-              with:
-                files: test-results.xml
+              run: pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
             - name: Ejecutar pruebas
               run: pytest -v --junit-xml=test-results.xml # el siguiente paso necesita los resultados en formato XML
             
-            - name: Mostrar resultados
-              if: always()
-              uses: pmeier/pytest-results-action@v0.3.0
+            - name: Publicar resultados
+              uses: EnricoMi/publish-unit-test-result-action@v2.7.0
               with:
-                path: test-results.xml
+                files: test-results.xml


### PR DESCRIPTION
Te comento. Las pocas veces que he probado a hacer tests unitarios con Python ha sido usando `unittest`, que viene por defecto con Python, y al ver en el título que usabas `pytest` lo he visto como una buena oportunidad para ver qué pinta tiene trabajar con ese framework (Además de que también me has enseñado cómo estructurar un proyecto) y qué te puedo decir, me ha maravillado

No obstante, se le puede dar un salto de calidad importante; probar todo el código con 1 comando está muy chuli, pero ahora imagínate que el código se prueba sólo cuando haces un push. Literalmente. Esas son las clases de maravillas que GitHub Actions te permite conseguir. Por eso, me he tomado la libertad de forkear éste repo e implementarlo

Entiendo perfectamente si no aceptas la pull request porque imagino que estás siguiendo una serie de vídeos y todavía no habías enseñado a usar ésta herramienta, pero es que yo mismo quería ver cómo se comportaba con `pytest` y nada, todo perfecto. Además, GitHub Actions también facilitaría mucho ejecutar éstas pruebas en más versiones de Python y/o en más sistemas operativos. ¿Te gustaría verlo?

Un abrazo
> Samuel